### PR TITLE
build(ci): update golangci-lint and Go version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,6 @@ jobs:
           go-version-file: go.mod
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.6
+          version: v2.7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module d7y.io/dragonfly-injector
 
-go 1.24.0
+go 1.25.5
 
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0


### PR DESCRIPTION
This pull request updates the Go version and the linter version used in the project to keep dependencies current and ensure compatibility with the latest tooling.

Dependency and tooling updates:

* Updated the Go version in `go.mod` from `1.24.0` to `1.25.5` to use the latest stable Go release.
* Upgraded the GitHub Actions linter workflow in `.github/workflows/lint.yml` to use `golangci/golangci-lint-action@v9` and bumped the linter version from `v2.1.6` to `v2.7`.