### PR TITLE
build(ci): limit build platforms to amd64 and arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ docker-push: ## Push docker image with the manager.
 # - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 # - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
 # To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
-PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+PLATFORMS ?= linux/arm64,linux/amd64
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,8 +44,6 @@ spec:
       #             values:
       #               - amd64
       #               - arm64
-      #               - ppc64le
-      #               - s390x
       #           - key: kubernetes.io/os
       #             operator: In
       #             values:


### PR DESCRIPTION
This pull request reduces the number of supported architectures for Docker image builds and deployment, focusing only on `amd64` and `arm64`. The changes remove support for `ppc64le` and `s390x` platforms from build, push, and deployment configurations.

**Platform support reduction:**

* Updated `.github/workflows/docker.yml` to only build and push Docker images for `linux/amd64` and `linux/arm64`, removing `linux/s390x` and `linux/ppc64le` from the `platforms` list.
* Changed the `PLATFORMS` variable in the `Makefile` to default to `linux/arm64,linux/amd64` only, dropping `linux/s390x` and `linux/ppc64le`.

**Deployment configuration update:**

* Removed commented-out references to `ppc64le` and `s390x` architectures from the `config/manager/manager.yaml` deployment spec.