### PR TITLE
ci: rename image from dragonfly-injector to injector

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: dragonflyoss/dragonfly-injector
+          images: dragonflyoss/injector
           tags: |
             # For tag events: v1.2.3 -> 1.2.3, latest
             type=semver,pattern={{version}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           # Replace the image tag in kustomize config with the release tag
           VERSION=${GITHUB_REF#refs/tags/}
-          make build-installer IMG=dragonflyoss/dragonfly-injector:${VERSION#v}
+          make build-installer IMG=dragonflyoss/injector:${VERSION#v}
 
       - name: Generate changelog
         id: changelog
@@ -53,7 +53,7 @@ jobs:
           echo "## Docker Image" >> changelog.md
           echo "" >> changelog.md
           echo '```' >> changelog.md
-          echo "docker pull dragonflyoss/dragonfly-injector:${CURRENT_TAG#v}" >> changelog.md
+          echo "docker pull dragonflyoss/injector:${CURRENT_TAG#v}" >> changelog.md
           echo '```' >> changelog.md
 
           echo "" >> changelog.md


### PR DESCRIPTION
This pull request updates the Docker image naming convention across the project's GitHub Actions workflows, standardizing the image name from `dragonflyoss/dragonfly-injector` to `dragonflyoss/injector`. This ensures consistency in image references throughout the build, release, and documentation processes.

**Workflow and Documentation Updates:**

* Updated the Docker image name from `dragonflyoss/dragonfly-injector` to `dragonflyoss/injector` in the Docker metadata action within `.github/workflows/docker.yml`.
* Changed the image name used during the installer build step in the release workflow to match the new convention in `.github/workflows/release.yml`.
* Updated the changelog generation script to reference the new Docker image name in `.github/workflows/release.yml`.