### PR TITLE
webhook: add idempotency check and configurable unix socket path

### DIFF
--- a/config/webhook/config-map.yaml
+++ b/config/webhook/config-map.yaml
@@ -11,3 +11,4 @@ data:
       digest: ''
       pullPolicy: IfNotPresent
       pullSecrets: []
+    unixSockPath: /var/run/dragonfly/dfdaemon.sock

--- a/internal/webhook/v1/injector/config.go
+++ b/internal/webhook/v1/injector/config.go
@@ -33,6 +33,7 @@ var logger = log.Log.WithName("dragonfly-inject")
 // Config is the configuration for dragonfly injection.
 type Config struct {
 	InitContainerImage InitContainerImage `yaml:"initContainerImage" json:"initContainerImage"`
+	UnixSockPath       string             `yaml:"unixSockPath" json:"unixSockPath"`
 }
 
 // InitContainerImage is the image configuration for the init container.
@@ -67,6 +68,7 @@ func DefaultConfig() *Config {
 			PullPolicy:  "IfNotPresent",
 			PullSecrets: []corev1.LocalObjectReference{},
 		},
+		UnixSockPath: DfdaemonUnixSockPath,
 	}
 }
 

--- a/internal/webhook/v1/injector/config_test.go
+++ b/internal/webhook/v1/injector/config_test.go
@@ -119,6 +119,7 @@ var _ = Describe("Config", func() {
 			Expect(defaultConfig.InitContainerImage.Digest).To(BeEmpty())
 			Expect(defaultConfig.InitContainerImage.PullPolicy).To(Equal(corev1.PullPolicy("IfNotPresent")))
 			Expect(defaultConfig.InitContainerImage.PullSecrets).To(BeEmpty())
+			Expect(defaultConfig.UnixSockPath).To(Equal(DfdaemonUnixSockPath))
 		})
 	})
 

--- a/internal/webhook/v1/injector/constant.go
+++ b/internal/webhook/v1/injector/constant.go
@@ -38,6 +38,10 @@ const (
 	PodInjectAnnotationName  string = Domain + "/" + "inject"
 	PodInjectAnnotationValue string = "true"
 
+	// Injection status annotation for idempotency.
+	InjectedAnnotationName  string = Domain + "/" + "injected"
+	InjectedAnnotationValue string = "true"
+
 	// Dfdaemon unix sock config.
 	SkipUnixSockInjectAnnotationName  string = Domain + "/" + "skip-unix-sock-inject"
 	SkipUnixSockInjectAnnotationValue string = "true"

--- a/internal/webhook/v1/injector/unix_socket.go
+++ b/internal/webhook/v1/injector/unix_socket.go
@@ -34,13 +34,18 @@ func (us *UnixSocket) Inject(pod *corev1.Pod, config *Config) {
 		return
 	}
 
+	sockPath := config.UnixSockPath
+	if sockPath == "" {
+		sockPath = DfdaemonUnixSockPath
+	}
+
 	if !us.hasVolume(pod) {
 		hostPathType := corev1.HostPathSocket
 		dfdaemonSocketVolume := corev1.Volume{
 			Name: DfdaemonUnixSockVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: DfdaemonUnixSockPath,
+					Path: sockPath,
 					Type: &hostPathType,
 				},
 			},
@@ -52,7 +57,7 @@ func (us *UnixSocket) Inject(pod *corev1.Pod, config *Config) {
 		if !us.hasVolumeMount(&c) {
 			dfdaemonSocketVolumeMount := corev1.VolumeMount{
 				Name:      DfdaemonUnixSockVolumeName,
-				MountPath: DfdaemonUnixSockPath,
+				MountPath: sockPath,
 			}
 			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, dfdaemonSocketVolumeMount)
 		}

--- a/internal/webhook/v1/injector/unix_socket_test.go
+++ b/internal/webhook/v1/injector/unix_socket_test.go
@@ -54,6 +54,55 @@ var _ = Describe("UnixSocketInjector", func() {
 		}
 	}
 
+	Context("when using a custom unix socket path from config", func() {
+		It("should use the custom path from config for volume and mount", func() {
+			By("creating a pod")
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod-custom-path"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "container-1"}},
+				},
+			}
+
+			customPath := "/custom/path/dfdaemon.sock"
+			config := &Config{UnixSockPath: customPath}
+
+			By("performing injection with custom config")
+			injector.Inject(pod, config)
+
+			By("verifying volume uses custom path")
+			Expect(pod.Spec.Volumes).To(HaveLen(1))
+			Expect(pod.Spec.Volumes[0].HostPath.Path).To(Equal(customPath))
+
+			By("verifying volume mount uses custom path")
+			Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(1))
+			Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal(customPath))
+		})
+
+		It("should fall back to default path when config has empty UnixSockPath", func() {
+			By("creating a pod")
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod-default-path"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "container-1"}},
+				},
+			}
+
+			config := &Config{UnixSockPath: ""}
+
+			By("performing injection with empty path config")
+			injector.Inject(pod, config)
+
+			By("verifying volume uses default path")
+			Expect(pod.Spec.Volumes).To(HaveLen(1))
+			Expect(pod.Spec.Volumes[0].HostPath.Path).To(Equal(DfdaemonUnixSockPath))
+
+			By("verifying volume mount uses default path")
+			Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(1))
+			Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal(DfdaemonUnixSockPath))
+		})
+	})
+
 	Context("when injecting unix socket volume and mounts", func() {
 		It("should inject into a pod with no existing volume or volume mounts", func() {
 			By("creating a simple pod")

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -97,6 +97,12 @@ func (d *PodCustomDefaulter) applyDefaults(ctx context.Context, pod *corev1.Pod)
 		return
 	}
 
+	// Idempotency: skip pods that have already been injected.
+	if d.isAlreadyInjected(pod) {
+		logger.Info("Pod already injected, skip", "pod namespace", pod.GetNamespace(), "pod name", pod.GetName())
+		return
+	}
+
 	// Check if need inject.
 	if !d.needInject(ctx, pod) {
 		logger.Info("Pod not inject", "pod namespace", pod.GetNamespace(), "pod name", pod.GetName())
@@ -106,6 +112,21 @@ func (d *PodCustomDefaulter) applyDefaults(ctx context.Context, pod *corev1.Pod)
 	for _, ij := range d.injectors {
 		ij.Inject(pod, config)
 	}
+
+	// Mark pod as injected to prevent double injection.
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	pod.Annotations[injector.InjectedAnnotationName] = injector.InjectedAnnotationValue
+}
+
+func (d *PodCustomDefaulter) isAlreadyInjected(pod *corev1.Pod) bool {
+	annotations := pod.GetAnnotations()
+	if len(annotations) == 0 {
+		return false
+	}
+	v, ok := annotations[injector.InjectedAnnotationName]
+	return ok && v == injector.InjectedAnnotationValue
 }
 
 func (d *PodCustomDefaulter) needInject(ctx context.Context, pod *corev1.Pod) bool {

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -115,6 +115,80 @@ var _ = Describe("Pod Webhook", func() {
 		defaulter.injectors = []Injector{mockInj}
 	}
 
+	Context("When checking idempotency", func() {
+		It("should skip injection if the pod already has the injected annotation", func() {
+			By("creating a namespace with the injection label")
+			labeledNs := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNsName,
+					Labels: map[string]string{
+						injector.NamespaceInjectLabelName: injector.NamespaceInjectLabelValue,
+					},
+				},
+			}
+			setupDefaulter(labeledNs)
+
+			By("marking the pod as already injected")
+			testPod.Annotations[injector.InjectedAnnotationName] = injector.InjectedAnnotationValue
+
+			By("calling the Default method")
+			err := defaulter.Default(ctx, testPod)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the injector was NOT called")
+			Expect(mockInj.called).To(BeFalse())
+		})
+
+		It("should set the injected annotation after successful injection", func() {
+			By("creating a namespace with the injection label")
+			labeledNs := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNsName,
+					Labels: map[string]string{
+						injector.NamespaceInjectLabelName: injector.NamespaceInjectLabelValue,
+					},
+				},
+			}
+			setupDefaulter(labeledNs)
+
+			By("calling the Default method")
+			err := defaulter.Default(ctx, testPod)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the injector was called")
+			Expect(mockInj.called).To(BeTrue())
+
+			By("verifying the injected annotation was set")
+			Expect(testPod.Annotations[injector.InjectedAnnotationName]).To(Equal(injector.InjectedAnnotationValue))
+		})
+
+		It("should not double-inject on a second call", func() {
+			By("creating a namespace with the injection label")
+			labeledNs := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNsName,
+					Labels: map[string]string{
+						injector.NamespaceInjectLabelName: injector.NamespaceInjectLabelValue,
+					},
+				},
+			}
+			setupDefaulter(labeledNs)
+
+			By("calling the Default method the first time")
+			err := defaulter.Default(ctx, testPod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockInj.called).To(BeTrue())
+
+			By("resetting the mock and calling Default a second time")
+			mockInj.Reset()
+			err = defaulter.Default(ctx, testPod)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the injector was NOT called the second time")
+			Expect(mockInj.called).To(BeFalse())
+		})
+	})
+
 	Context("When evaluating if injection is required", func() {
 
 		Context("and injection is enabled by Namespace label", func() {


### PR DESCRIPTION
## What this PR does

Part of dragonflyoss/dragonfly#4416. Adds idempotency check (dragonfly.io/injected annotation) to prevent double injection, makes unix socket path configurable via InjectConf, and adds tests.

Ref: https://github.com/dragonflyoss/dragonfly/issues/4416