### PR TITLE
ci: add repository guard to Docker and Release workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   docker:
+    if: github.repository == 'dragonflyoss/dragonfly-injector'
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   release:
+    if: github.repository == 'dragonflyoss/dragonfly-injector'
     name: Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### What this PR does

Adds `if: github.repository == 'dragonflyoss/dragonfly-injector'` guard to the `docker` and `release` workflow jobs to prevent them from running on forks, where Docker Hub secrets are unavailable and cause CI failures.

Fixes: #15

### Changes

- `.github/workflows/docker.yml` — add repository check at job level
- `.github/workflows/release.yml` — add repository check at job level

### Why

Forks don't have `DOCKER_USERNAME` / `DOCKER_PASSWORD` secrets, so the Docker Publish workflow fails on every push to a fork's `main` branch. The guard skips these jobs entirely on forks, saving CI time and avoiding red ❌s.