### PR TITLE
ci(docker): refactor workflow with versioning, GHCR support, and caching

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - "v*"
+      - 'v*'
 
 jobs:
   docker:
@@ -15,40 +15,76 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      - name: Get Version
+        id: get_version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          if [[ ${GITHUB_REF} == "refs/heads/main" || ${GITHUB_REF} =~ refs/pull/([0-9]+)/merge ]]; then
+            VERSION=latest
+          fi
 
-      - name: Set up Docker Buildx
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Get Git Revision
+        id: vars
+        shell: bash
+        run: |
+          echo "git_revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: PrepareReg Names
+        run: |
+          echo IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Login to DockerHub
+      - name: Cache Docker layers
+        uses: actions/cache@v5
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login Docker Hub
         uses: docker/login-action@v4
         with:
+          registry: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v6
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
         with:
-          images: dragonflyoss/injector
-          tags: |
-            # For tag events: v1.2.3 -> 1.2.3, latest
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            # For main branch push: latest
-            type=raw,value=latest,enable={{is_default_branch}}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          labels: |-
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
           build-args: |
             GO111MODULE=on
+            GITVERSION=git-${{ steps.vars.outputs.git_revision }}
+            VERSION=${{ steps.get_version.outputs.VERSION }}
+          tags: |
+            dragonflyoss/injector:${{ steps.get_version.outputs.VERSION }}
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/injector:${{ steps.get_version.outputs.VERSION }}
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Docker build workflow in `.github/workflows/docker.yml` to improve versioning, caching, and multi-registry publishing. The workflow now automatically sets image tags based on the current branch or tag, caches Docker layers for faster builds, and pushes images to both Docker Hub and GitHub Container Registry.

**Docker build and publishing improvements:**

* Added steps to dynamically determine and set the `VERSION` and Git revision for Docker image tags, ensuring images are correctly versioned for both main and tag builds.
* Updated the workflow to push Docker images to both Docker Hub and GitHub Container Registry, including proper authentication steps for each registry.
* Replaced the Docker metadata action with explicit tag and label generation, simplifying tag management and making image provenance clearer.

**Build performance enhancements:**

* Introduced Docker layer caching using the `actions/cache` action and local cache mounts, which speeds up subsequent builds by reusing unchanged layers.

**Maintenance and consistency:**

* Changed the QEMU setup action to use version 3 for compatibility and consistency with other actions.
* Minor syntax change for tag pattern from double to single quotes for consistency.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
