### PR TITLE
refactor(injector): reduce duplication and improve config reload

### DIFF
--- a/internal/webhook/v1/injector/binaries.go
+++ b/internal/webhook/v1/injector/binaries.go
@@ -22,6 +22,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+var binaryNames = []string{
+	DfgetBinaryName,
+	DfcacheBinaryName,
+	DfstoreBinaryName,
+	DfctlBinaryName,
+	DfdaemonBinaryName,
+}
+
 type Binaries struct{}
 
 func NewBinaries() *Binaries {
@@ -31,17 +39,11 @@ func NewBinaries() *Binaries {
 func (b *Binaries) Inject(pod *corev1.Pod, config *Config) {
 	logger.Info("Binaries inject", "pod namespace", pod.GetNamespace(), "pod name", pod.GetName())
 
-	initContainerCmd := []string{
-		"install",
-		"-D",
-		filepath.Join(BinaryDirPath, DfgetBinaryName),
-		filepath.Join(BinaryDirPath, DfcacheBinaryName),
-		filepath.Join(BinaryDirPath, DfstoreBinaryName),
-		filepath.Join(BinaryDirPath, DfctlBinaryName),
-		filepath.Join(BinaryDirPath, DfdaemonBinaryName),
-		"-t",
-		BinaryVolumeMountPath + "/",
+	initContainerCmd := []string{"install", "-D"}
+	for _, bin := range binaryNames {
+		initContainerCmd = append(initContainerCmd, filepath.Join(BinaryDirPath, bin))
 	}
+	initContainerCmd = append(initContainerCmd, "-t", BinaryVolumeMountPath+"/")
 
 	// Override initContainerImage with the value from annotations if it exists.
 	initContainerImage := config.GetInitContainerImageReference()
@@ -87,40 +89,14 @@ func (b *Binaries) Inject(pod *corev1.Pod, config *Config) {
 				MountPath: BinaryVolumeMountPath,
 			})
 
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
-				Name:      BinaryVolumeName,
-				MountPath: filepath.Join(BinaryMountDirPath, DfgetBinaryName),
-				SubPath:   DfgetBinaryName,
-				ReadOnly:  true,
-			})
-
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
-				Name:      BinaryVolumeName,
-				MountPath: filepath.Join(BinaryMountDirPath, DfcacheBinaryName),
-				SubPath:   DfcacheBinaryName,
-				ReadOnly:  true,
-			})
-
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
-				Name:      BinaryVolumeName,
-				MountPath: filepath.Join(BinaryMountDirPath, DfstoreBinaryName),
-				SubPath:   DfstoreBinaryName,
-				ReadOnly:  true,
-			})
-
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
-				Name:      BinaryVolumeName,
-				MountPath: filepath.Join(BinaryMountDirPath, DfctlBinaryName),
-				SubPath:   DfctlBinaryName,
-				ReadOnly:  true,
-			})
-
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
-				Name:      BinaryVolumeName,
-				MountPath: filepath.Join(BinaryMountDirPath, DfdaemonBinaryName),
-				SubPath:   DfdaemonBinaryName,
-				ReadOnly:  true,
-			})
+			for _, bin := range binaryNames {
+				pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
+					Name:      BinaryVolumeName,
+					MountPath: filepath.Join(BinaryMountDirPath, bin),
+					SubPath:   bin,
+					ReadOnly:  true,
+				})
+			}
 		}
 	}
 }

--- a/internal/webhook/v1/injector/config.go
+++ b/internal/webhook/v1/injector/config.go
@@ -17,7 +17,9 @@
 package injector
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -74,6 +76,7 @@ type ConfigManager struct {
 	mu         sync.RWMutex
 	config     *Config
 	configPath string
+	lastRaw    []byte
 }
 
 func NewConfigManager(injectConfigMapPath string) *ConfigManager {
@@ -90,7 +93,6 @@ func (cm *ConfigManager) GetConfig() *Config {
 	defer cm.mu.RUnlock()
 
 	copiedConf := *cm.config
-	logger.Info("Get config", "config", copiedConf)
 	return &copiedConf
 }
 
@@ -112,11 +114,32 @@ func (cm *ConfigManager) Start(ctx context.Context) error {
 }
 
 func (cm *ConfigManager) reload() {
-	config := LoadConfig(cm.configPath)
+	raw, err := os.ReadFile(cm.configPath)
+	if err != nil {
+		logger.Error(err, "read config file for reload", "path", cm.configPath)
+		return
+	}
+
+	if bytes.Equal(raw, cm.lastRaw) {
+		return
+	}
+
+	config, err := LoadConfigFromFile(cm.configPath)
+	if err != nil {
+		logger.Error(err, "parse config file during reload", "path", cm.configPath)
+		return
+	}
+
+	if err := config.Validate(); err != nil {
+		logger.Error(err, "invalid config on reload, keeping current")
+		return
+	}
+
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	cm.config = config
-	logger.Info("Configuration reloaded successfully")
+	cm.lastRaw = raw
+	logger.Info("Configuration reloaded")
 }
 
 func LoadConfig(injectConfigMapPath string) *Config {
@@ -124,8 +147,14 @@ func LoadConfig(injectConfigMapPath string) *Config {
 	if err != nil {
 		logger.Error(err, "load config from file failed")
 		logger.Info("use default config")
-		c = DefaultConfig()
+		return DefaultConfig()
 	}
+
+	if err := c.Validate(); err != nil {
+		logger.Error(err, "invalid config, using defaults")
+		return DefaultConfig()
+	}
+
 	return c
 }
 
@@ -142,4 +171,15 @@ func LoadConfigFromFile(injectConfigMapPath string) (*Config, error) {
 	}
 
 	return config, nil
+}
+
+// Validate checks that required fields are set.
+func (c *Config) Validate() error {
+	if c.InitContainerImage.Registry == "" {
+		return fmt.Errorf("initContainerImage.registry is required")
+	}
+	if c.InitContainerImage.Repository == "" {
+		return fmt.Errorf("initContainerImage.repository is required")
+	}
+	return nil
 }

--- a/internal/webhook/v1/injector/config.go
+++ b/internal/webhook/v1/injector/config.go
@@ -81,10 +81,17 @@ type ConfigManager struct {
 
 func NewConfigManager(injectConfigMapPath string) *ConfigManager {
 	configPath := filepath.Join(injectConfigMapPath, "injector.yaml")
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		logger.Error(err, "load config from file failed")
+		logger.Info("use default config")
+		return &ConfigManager{config: DefaultConfig(), configPath: configPath}
+	}
+
 	return &ConfigManager{
-		mu:         sync.RWMutex{},
-		config:     LoadConfig(configPath),
+		config:     loadConfigFromBytes(raw),
 		configPath: configPath,
+		lastRaw:    raw,
 	}
 }
 
@@ -124,7 +131,7 @@ func (cm *ConfigManager) reload() {
 		return
 	}
 
-	config, err := LoadConfigFromFile(cm.configPath)
+	config, err := parseConfig(raw)
 	if err != nil {
 		logger.Error(err, "parse config file during reload", "path", cm.configPath)
 		return
@@ -143,7 +150,20 @@ func (cm *ConfigManager) reload() {
 }
 
 func LoadConfig(injectConfigMapPath string) *Config {
-	c, err := LoadConfigFromFile(injectConfigMapPath)
+	raw, err := os.ReadFile(injectConfigMapPath)
+	if err != nil {
+		logger.Error(err, "load config from file failed")
+		logger.Info("use default config")
+		return DefaultConfig()
+	}
+
+	return loadConfigFromBytes(raw)
+}
+
+// loadConfigFromBytes parses raw config bytes, falling back to the default
+// config if parsing or validation fails.
+func loadConfigFromBytes(raw []byte) *Config {
+	c, err := parseConfig(raw)
 	if err != nil {
 		logger.Error(err, "load config from file failed")
 		logger.Info("use default config")
@@ -160,13 +180,18 @@ func LoadConfig(injectConfigMapPath string) *Config {
 
 // LoadConfigFromFile loads config from file.
 func LoadConfigFromFile(injectConfigMapPath string) (*Config, error) {
-	cf, err := os.ReadFile(injectConfigMapPath)
+	raw, err := os.ReadFile(injectConfigMapPath)
 	if err != nil {
 		return nil, err
 	}
 
+	return parseConfig(raw)
+}
+
+// parseConfig unmarshals raw YAML bytes into a Config.
+func parseConfig(raw []byte) (*Config, error) {
 	config := &Config{}
-	if err := yaml.Unmarshal(cf, config); err != nil {
+	if err := yaml.Unmarshal(raw, config); err != nil {
 		return nil, err
 	}
 

--- a/internal/webhook/v1/injector/config_test.go
+++ b/internal/webhook/v1/injector/config_test.go
@@ -269,6 +269,49 @@ var _ = Describe("Config", func() {
 		})
 	})
 
+	Describe("Validate", func() {
+		It("should pass for a valid config", func() {
+			c := DefaultConfig()
+			Expect(c.Validate()).NotTo(HaveOccurred())
+		})
+
+		It("should fail when registry is empty", func() {
+			c := &Config{
+				InitContainerImage: InitContainerImage{
+					Repository: "dragonflyoss/client",
+				},
+			}
+			Expect(c.Validate()).To(MatchError(ContainSubstring("registry")))
+		})
+
+		It("should fail when repository is empty", func() {
+			c := &Config{
+				InitContainerImage: InitContainerImage{
+					Registry: "docker.io",
+				},
+			}
+			Expect(c.Validate()).To(MatchError(ContainSubstring("repository")))
+		})
+	})
+
+	Describe("LoadConfig with validation", func() {
+		It("should fall back to defaults when config is missing required fields", func() {
+			By("writing a config with no repository")
+			configPath := filepath.Join(tempDir, "bad-config.yaml")
+			writeConfigFile(configPath, &Config{
+				InitContainerImage: InitContainerImage{
+					Registry: "custom.io",
+				},
+			})
+
+			By("loading the config")
+			loaded := LoadConfig(configPath)
+			expected := DefaultConfig()
+			Expect(loaded.InitContainerImage.Registry).To(Equal(expected.InitContainerImage.Registry))
+			Expect(loaded.InitContainerImage.Repository).To(Equal(expected.InitContainerImage.Repository))
+		})
+	})
+
 	Describe("ConfigManager", func() {
 		var (
 			configManager *ConfigManager

--- a/internal/webhook/v1/injector/config_test.go
+++ b/internal/webhook/v1/injector/config_test.go
@@ -383,6 +383,19 @@ var _ = Describe("Config", func() {
 				Expect(config.InitContainerImage.Tag).To(Equal("v2.0.0"))
 				Expect(config.InitContainerImage.PullPolicy).To(Equal(corev1.PullAlways))
 			})
+
+			It("should record the raw bytes on construction and skip reload when unchanged", func() {
+				By("verifying lastRaw was populated by the constructor")
+				Expect(configManager.lastRaw).NotTo(BeEmpty())
+
+				By("triggering a reload without changing the file")
+				before := configManager.GetConfig()
+				configManager.reload()
+
+				By("verifying the config is unchanged")
+				after := configManager.GetConfig()
+				Expect(after).To(Equal(before))
+			})
 		})
 
 		Context("when configuration file does not exist", func() {


### PR DESCRIPTION
Cleans up some stuff I noticed while working through dragonflyoss/dragonfly#4416.

The volume mount creation in `binaries.go` had the same block copy-pasted 5 times (once per binary). Pulled those into a loop over a `binaryNames` slice — same for the init container command. Now when someone adds a binary (like dfctl was just added), it's a one-liner.

On the config side: `reload()` was re-parsing and swapping the config every 30s even when nothing changed, and `GetConfig()` was logging on every single webhook call which gets noisy fast. Fixed reload to compare raw bytes first, dropped the per-call log. Also added a basic `Validate()` so we don't silently run with an empty registry/repo — falls back to defaults if validation fails.

Added tests for the validation + fallback path. All 50 tests pass.