### PR TITLE
feat(injector): support init-container workloads via annotations

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -101,6 +101,26 @@
            name: dragonfly-binaries-volume
    ```
 
+## Init-container workloads
+
+By default the binaries and the dfdaemon socket are mounted only on the main
+containers, and `dragonfly-binaries` is appended after any existing init containers.
+Workloads that call `dfget` from an init container (for example a download or warm-up
+step) need the binaries installed first and mounted on that init container. Two opt-in
+annotations enable this:
+
+```yaml
+metadata:
+  annotations:
+    dragonfly.io/inject: 'true'
+    dragonfly.io/binaries-init-first: 'true'
+    dragonfly.io/inject-init-containers: 'true'
+```
+
+`dragonfly.io/binaries-init-first` installs `dragonfly-binaries` before the other init
+containers, and `dragonfly.io/inject-init-containers` mounts the binaries and the
+dfdaemon socket on every init container except the installer itself.
+
 ## Undeploy
 
 ```sh

--- a/internal/webhook/v1/injector/annotations.go
+++ b/internal/webhook/v1/injector/annotations.go
@@ -1,0 +1,55 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package injector
+
+import corev1 "k8s.io/api/core/v1"
+
+// podAnnotationEnabled checks if the pod annotation key is set to value.
+func podAnnotationEnabled(annotations map[string]string, key, value string) bool {
+	v, ok := annotations[key]
+	return ok && v == value
+}
+
+// skipUnixSockInjectEnabled checks if the dfdaemon socket mount should be skipped.
+func skipUnixSockInjectEnabled(pod *corev1.Pod) bool {
+	return podAnnotationEnabled(pod.Annotations, SkipUnixSockInjectAnnotationName, SkipUnixSockInjectAnnotationValue)
+}
+
+// injectInitContainersEnabled checks if mounts should also be added to init containers.
+func injectInitContainersEnabled(pod *corev1.Pod) bool {
+	return podAnnotationEnabled(pod.Annotations, InjectInitContainersAnnotationName, InjectInitContainersAnnotationValue)
+}
+
+// binariesInitFirstEnabled checks if dragonfly-binaries should be inserted first.
+func binariesInitFirstEnabled(pod *corev1.Pod) bool {
+	return podAnnotationEnabled(pod.Annotations, BinariesInitFirstAnnotationName, BinariesInitFirstAnnotationValue)
+}
+
+// forEachNonInstallerInitContainer applies fn to each init container except the
+// dragonfly-binaries installer, but only when inject-init-containers is enabled.
+func forEachNonInstallerInitContainer(pod *corev1.Pod, fn func(*corev1.Container)) {
+	if !injectInitContainersEnabled(pod) {
+		return
+	}
+
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == InitContainerName {
+			continue
+		}
+		fn(&pod.Spec.InitContainers[i])
+	}
+}

--- a/internal/webhook/v1/injector/annotations_test.go
+++ b/internal/webhook/v1/injector/annotations_test.go
@@ -1,0 +1,58 @@
+/*
+ *     Copyright 2026 The Dragonfly Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package injector
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Pod injection annotations", func() {
+	It("defaults opt-in annotations to false", func() {
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod"}}
+		Expect(injectInitContainersEnabled(pod)).To(BeFalse())
+		Expect(binariesInitFirstEnabled(pod)).To(BeFalse())
+	})
+
+	It("enables features only when the annotation value is true", func() {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					InjectInitContainersAnnotationName: "false",
+					BinariesInitFirstAnnotationName:    "yes",
+				},
+			},
+		}
+		Expect(injectInitContainersEnabled(pod)).To(BeFalse())
+		Expect(binariesInitFirstEnabled(pod)).To(BeFalse())
+	})
+
+	It("enables features when the annotation value is true", func() {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					InjectInitContainersAnnotationName: InjectInitContainersAnnotationValue,
+					BinariesInitFirstAnnotationName:    BinariesInitFirstAnnotationValue,
+				},
+			},
+		}
+		Expect(injectInitContainersEnabled(pod)).To(BeTrue())
+		Expect(binariesInitFirstEnabled(pod)).To(BeTrue())
+	})
+})

--- a/internal/webhook/v1/injector/binaries.go
+++ b/internal/webhook/v1/injector/binaries.go
@@ -22,6 +22,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// binaryNames are the dragonfly binaries copied from the client image and mounted into pods.
+var binaryNames = []string{
+	DfgetBinaryName,
+	DfcacheBinaryName,
+	DfstoreBinaryName,
+	DfctlBinaryName,
+	DfdaemonBinaryName,
+}
+
 type Binaries struct{}
 
 func NewBinaries() *Binaries {
@@ -30,18 +39,6 @@ func NewBinaries() *Binaries {
 
 func (b *Binaries) Inject(pod *corev1.Pod, config *Config) {
 	logger.Info("Binaries inject", "pod namespace", pod.GetNamespace(), "pod name", pod.GetName())
-
-	initContainerCmd := []string{
-		"install",
-		"-D",
-		filepath.Join(BinaryDirPath, DfgetBinaryName),
-		filepath.Join(BinaryDirPath, DfcacheBinaryName),
-		filepath.Join(BinaryDirPath, DfstoreBinaryName),
-		filepath.Join(BinaryDirPath, DfctlBinaryName),
-		filepath.Join(BinaryDirPath, DfdaemonBinaryName),
-		"-t",
-		BinaryVolumeMountPath + "/",
-	}
 
 	// Override initContainerImage with the value from annotations if it exists.
 	initContainerImage := config.GetInitContainerImageReference()
@@ -64,9 +61,15 @@ func (b *Binaries) Inject(pod *corev1.Pod, config *Config) {
 					MountPath: BinaryVolumeMountPath,
 				},
 			},
-			Command: initContainerCmd,
+			Command: binaryInstallCommand(),
 		}
-		pod.Spec.InitContainers = append(pod.Spec.InitContainers, *toolContainer)
+
+		// Prepend so the binaries install before init containers that use them, otherwise append.
+		if binariesInitFirstEnabled(pod) {
+			pod.Spec.InitContainers = append([]corev1.Container{*toolContainer}, pod.Spec.InitContainers...)
+		} else {
+			pod.Spec.InitContainers = append(pod.Spec.InitContainers, *toolContainer)
+		}
 		pod.Spec.ImagePullSecrets = append(pod.Spec.ImagePullSecrets, config.InitContainerImage.PullSecrets...)
 	}
 
@@ -81,47 +84,41 @@ func (b *Binaries) Inject(pod *corev1.Pod, config *Config) {
 	}
 
 	for i := range pod.Spec.Containers {
-		if !b.hasVolumeMount(&pod.Spec.Containers[i]) {
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
-				Name:      BinaryVolumeName,
-				MountPath: BinaryVolumeMountPath,
-			})
+		b.injectVolumeMounts(&pod.Spec.Containers[i])
+	}
 
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
-				Name:      BinaryVolumeName,
-				MountPath: filepath.Join(BinaryMountDirPath, DfgetBinaryName),
-				SubPath:   DfgetBinaryName,
-				ReadOnly:  true,
-			})
+	forEachNonInstallerInitContainer(pod, b.injectVolumeMounts)
+}
 
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
-				Name:      BinaryVolumeName,
-				MountPath: filepath.Join(BinaryMountDirPath, DfcacheBinaryName),
-				SubPath:   DfcacheBinaryName,
-				ReadOnly:  true,
-			})
+// binaryInstallCommand copies the dragonfly binaries from the client image into the shared volume.
+func binaryInstallCommand() []string {
+	cmd := make([]string, 0, len(binaryNames)+4)
+	cmd = append(cmd, "install", "-D")
+	for _, bin := range binaryNames {
+		cmd = append(cmd, filepath.Join(BinaryDirPath, bin))
+	}
 
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
-				Name:      BinaryVolumeName,
-				MountPath: filepath.Join(BinaryMountDirPath, DfstoreBinaryName),
-				SubPath:   DfstoreBinaryName,
-				ReadOnly:  true,
-			})
+	return append(cmd, "-t", BinaryVolumeMountPath+"/")
+}
 
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
-				Name:      BinaryVolumeName,
-				MountPath: filepath.Join(BinaryMountDirPath, DfctlBinaryName),
-				SubPath:   DfctlBinaryName,
-				ReadOnly:  true,
-			})
+// injectVolumeMounts mounts the shared volume and each binary subpath into the container.
+func (b *Binaries) injectVolumeMounts(c *corev1.Container) {
+	if b.hasVolumeMount(c) {
+		return
+	}
 
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
-				Name:      BinaryVolumeName,
-				MountPath: filepath.Join(BinaryMountDirPath, DfdaemonBinaryName),
-				SubPath:   DfdaemonBinaryName,
-				ReadOnly:  true,
-			})
-		}
+	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
+		Name:      BinaryVolumeName,
+		MountPath: BinaryVolumeMountPath,
+	})
+
+	for _, bin := range binaryNames {
+		c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
+			Name:      BinaryVolumeName,
+			MountPath: filepath.Join(BinaryMountDirPath, bin),
+			SubPath:   bin,
+			ReadOnly:  true,
+		})
 	}
 }
 

--- a/internal/webhook/v1/injector/binaries_test.go
+++ b/internal/webhook/v1/injector/binaries_test.go
@@ -368,7 +368,7 @@ var _ = Describe("BinariesInjector", func() {
 
 				By("verifying existing volume mount is preserved and new ones are appended")
 				Expect(pod.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("existing-mount"))
-				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(7)) // 1 existing + 5 new
+				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(7)) // 1 existing + 6 new
 			})
 		})
 
@@ -400,6 +400,77 @@ var _ = Describe("BinariesInjector", func() {
 				Expect(pod.Spec.ImagePullSecrets).To(HaveLen(2))
 				Expect(pod.Spec.ImagePullSecrets[0].Name).To(Equal("existing-secret"))
 				Expect(pod.Spec.ImagePullSecrets[1].Name).To(Equal("new-secret"))
+			})
+		})
+
+		Context("when binaries-init-first is enabled", func() {
+			It("should prepend dragonfly-binaries before existing init containers", func() {
+				By("creating a pod with an existing init container and binaries-init-first annotation")
+				pod := makePod("prepend-pod", 1, map[string]string{
+					BinariesInitFirstAnnotationName: BinariesInitFirstAnnotationValue,
+				})
+				pod.Spec.InitContainers = []corev1.Container{
+					{Name: "download-init", Image: "app:latest"},
+				}
+
+				By("performing injection")
+				binariesInjector.Inject(pod, defaultConfig)
+
+				By("verifying dragonfly-binaries is prepended before existing init containers")
+				Expect(pod.Spec.InitContainers).To(HaveLen(2))
+				Expect(pod.Spec.InitContainers[0].Name).To(Equal(InitContainerName))
+				Expect(pod.Spec.InitContainers[1].Name).To(Equal("download-init"))
+			})
+		})
+
+		Context("when inject-init-containers is enabled", func() {
+			It("should mount binaries into non-installer init containers", func() {
+				By("creating a pod with inject-init-containers and binaries-init-first annotations")
+				pod := makePod("init-mount-pod", 1, map[string]string{
+					BinariesInitFirstAnnotationName:    BinariesInitFirstAnnotationValue,
+					InjectInitContainersAnnotationName: InjectInitContainersAnnotationValue,
+				})
+				pod.Spec.InitContainers = []corev1.Container{
+					{Name: "download-init", Image: "app:latest"},
+				}
+
+				By("performing injection")
+				binariesInjector.Inject(pod, defaultConfig)
+
+				By("verifying volume mounts are added to the non-installer init container and main containers")
+				Expect(pod.Spec.InitContainers[1].VolumeMounts).To(Equal(makeExpectedVolumeMounts()))
+				Expect(pod.Spec.Containers[0].VolumeMounts).To(Equal(makeExpectedVolumeMounts()))
+			})
+
+			It("should not mount binaries into dragonfly-binaries itself", func() {
+				By("creating a pod with only the inject-init-containers annotation")
+				pod := makePod("installer-only-pod", 0, map[string]string{
+					InjectInitContainersAnnotationName: InjectInitContainersAnnotationValue,
+				})
+
+				By("performing injection")
+				binariesInjector.Inject(pod, defaultConfig)
+
+				By("verifying dragonfly-binaries keeps only the installer volume mount")
+				Expect(pod.Spec.InitContainers).To(HaveLen(1))
+				Expect(pod.Spec.InitContainers[0].Name).To(Equal(InitContainerName))
+				Expect(pod.Spec.InitContainers[0].VolumeMounts).To(HaveLen(1))
+				Expect(pod.Spec.InitContainers[0].VolumeMounts[0].MountPath).To(Equal(BinaryVolumeMountPath))
+			})
+
+			It("should not mount binaries into init containers when the annotation is absent", func() {
+				By("creating a pod with an existing init container and no inject-init-containers annotation")
+				pod := makePod("default-init-pod", 1, nil)
+				pod.Spec.InitContainers = []corev1.Container{
+					{Name: "download-init", Image: "app:latest"},
+				}
+
+				By("performing injection")
+				binariesInjector.Inject(pod, defaultConfig)
+
+				By("verifying the existing init container is left untouched")
+				Expect(pod.Spec.InitContainers[0].Name).To(Equal("download-init"))
+				Expect(pod.Spec.InitContainers[0].VolumeMounts).To(BeEmpty())
 			})
 		})
 	})

--- a/internal/webhook/v1/injector/constant.go
+++ b/internal/webhook/v1/injector/constant.go
@@ -45,11 +45,20 @@ const (
 	DfdaemonUnixSockPath              string = "/var/run/dragonfly/dfdaemon.sock"
 
 	InitContainerImageAnnotation string = Domain + "/" + "init-container-image"
-	InitContainerName            string = "dragonfly-binaries"
-	BinaryVolumeName             string = InitContainerName + "-" + "volume"
-	BinaryVolumeMountPath        string = "/dragonfly/bin"
-	BinaryDirPath                string = "/usr/local/bin"
-	BinaryMountDirPath           string = "/usr/local/bin"
+
+	// BinariesInitFirstAnnotationName prepends the dragonfly-binaries init container instead of appending it.
+	BinariesInitFirstAnnotationName  string = Domain + "/" + "binaries-init-first"
+	BinariesInitFirstAnnotationValue string = "true"
+
+	// InjectInitContainersAnnotationName also mounts the binaries and dfdaemon socket on init containers.
+	InjectInitContainersAnnotationName  string = Domain + "/" + "inject-init-containers"
+	InjectInitContainersAnnotationValue string = "true"
+
+	InitContainerName     string = "dragonfly-binaries"
+	BinaryVolumeName      string = InitContainerName + "-" + "volume"
+	BinaryVolumeMountPath string = "/dragonfly/bin"
+	BinaryDirPath         string = "/usr/local/bin"
+	BinaryMountDirPath    string = "/usr/local/bin"
 
 	DfgetBinaryName    string = "dfget"
 	DfcacheBinaryName  string = "dfcache"

--- a/internal/webhook/v1/injector/unix_socket.go
+++ b/internal/webhook/v1/injector/unix_socket.go
@@ -29,7 +29,7 @@ func NewUnixSocket() *UnixSocket {
 func (us *UnixSocket) Inject(pod *corev1.Pod, config *Config) {
 	logger.Info("UnixSocket inject", "pod namespace", pod.GetNamespace(), "pod name", pod.GetName())
 
-	if pod.Annotations != nil && pod.Annotations[SkipUnixSockInjectAnnotationName] == SkipUnixSockInjectAnnotationValue {
+	if skipUnixSockInjectEnabled(pod) {
 		logger.Info("UnixSocket inject skipped", "pod namespace", pod.GetNamespace(), "pod name", pod.GetName())
 		return
 	}
@@ -48,15 +48,23 @@ func (us *UnixSocket) Inject(pod *corev1.Pod, config *Config) {
 		pod.Spec.Volumes = append(pod.Spec.Volumes, dfdaemonSocketVolume)
 	}
 
-	for i, c := range pod.Spec.Containers {
-		if !us.hasVolumeMount(&c) {
-			dfdaemonSocketVolumeMount := corev1.VolumeMount{
-				Name:      DfdaemonUnixSockVolumeName,
-				MountPath: DfdaemonUnixSockPath,
-			}
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, dfdaemonSocketVolumeMount)
-		}
+	for i := range pod.Spec.Containers {
+		us.injectSocketVolumeMount(&pod.Spec.Containers[i])
 	}
+
+	forEachNonInstallerInitContainer(pod, us.injectSocketVolumeMount)
+}
+
+// injectSocketVolumeMount mounts the dfdaemon unix socket into the container.
+func (us *UnixSocket) injectSocketVolumeMount(c *corev1.Container) {
+	if us.hasVolumeMount(c) {
+		return
+	}
+
+	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
+		Name:      DfdaemonUnixSockVolumeName,
+		MountPath: DfdaemonUnixSockPath,
+	})
 }
 
 // hasVolume checks if the pod has the volume.

--- a/internal/webhook/v1/injector/unix_socket_test.go
+++ b/internal/webhook/v1/injector/unix_socket_test.go
@@ -260,4 +260,30 @@ var _ = Describe("UnixSocketInjector", func() {
 			Expect(pod).To(Equal(expectedPod))
 		})
 	})
+
+	Context("when inject-init-containers is enabled", func() {
+		It("should mount the socket into non-installer init containers", func() {
+			By("creating a pod with inject-init-containers annotation")
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "init-socket-pod",
+					Annotations: map[string]string{
+						InjectInitContainersAnnotationName: InjectInitContainersAnnotationValue,
+					},
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{Name: "download-init", Image: "app:latest"}},
+					Containers:     []corev1.Container{{Name: "app"}},
+				},
+			}
+
+			By("performing injection")
+			injector.Inject(pod, &Config{})
+
+			By("verifying the socket is mounted into init containers and main containers")
+			expectedVolumeMount := makeExpectedVolumeMount()
+			Expect(pod.Spec.InitContainers[0].VolumeMounts).To(Equal([]corev1.VolumeMount{expectedVolumeMount}))
+			Expect(pod.Spec.Containers[0].VolumeMounts).To(Equal([]corev1.VolumeMount{expectedVolumeMount}))
+		})
+	})
 })


### PR DESCRIPTION
## Description

Add two opt-in pod annotations so workloads that run `dfget` from an init container can use the webhook. Both are off by default, so existing pods are unaffected:

| Annotation | When `"true"` |
|------------|----------------|
| `dragonfly.io/binaries-init-first` | Insert `dragonfly-binaries` at the front of `spec.initContainers` |
| `dragonfly.io/inject-init-containers` | Also mount the binaries and the dfdaemon socket on init containers other than `dragonfly-binaries` |

With both enabled, the binaries are installed first and the downstream init container receives `/usr/local/bin/dfget` and the dfdaemon socket.

## Related Issue

#67

## Motivation and Context

Today the binaries and socket are mounted only on `spec.containers`, and `dragonfly-binaries` is appended after any existing init containers. A pod that calls `dfget` from an init container starts before the binaries are installed and never receives the mounts, so it can't use Dragonfly without manually duplicating the installer in its own spec.

## Screenshots (if appropriate)